### PR TITLE
Feature/add pixstack limit flag

### DIFF
--- a/PyZOGY/__main__.py
+++ b/PyZOGY/__main__.py
@@ -41,7 +41,7 @@ def main():
     parser.add_argument('--log', dest='log', help='Log output file', default='pyzogy.log')
     parser.add_argument('--percent', dest='percent', help='Pixel percentile for gain matching on pixels',
                         default=99)
-    parser.add_argument('--pixstack-limit', dest='pixstack_limit', type=int, help='Modify set_extract_pixstack in Sep', default=None)
+    parser.add_argument('--pixstack-limit', type=int, help='Modify set_extract_pixstack in Sep')
 
     args = parser.parse_args()
 

--- a/PyZOGY/__main__.py
+++ b/PyZOGY/__main__.py
@@ -41,7 +41,7 @@ def main():
     parser.add_argument('--log', dest='log', help='Log output file', default='pyzogy.log')
     parser.add_argument('--percent', dest='percent', help='Pixel percentile for gain matching on pixels',
                         default=99)
-
+    parser.add_argument('--pixstack-limit', dest='pixstack_limit', type=int, help='Modify set_extract_pixstack in Sep', default=None)
 
     args = parser.parse_args()
 
@@ -67,7 +67,8 @@ def main():
                                     matched_filter=args.matched_filter,
                                     percent=args.percent,
                                     corrected=args.correct,
-                                    photometry=args.photometry)
+                                    photometry=args.photometry,
+                                    pixstack_limit=args.pixstack_limit)
 
 if __name__ == '__main__':
     main()

--- a/PyZOGY/subtract.py
+++ b/PyZOGY/subtract.py
@@ -57,7 +57,7 @@ def calculate_difference_image(science, reference, gain_ratio=np.inf, gain_mask=
             science.mask[gain_mask_data == 1] = 1
             reference.mask[gain_mask_data == 1] = 1
         science.zero_point = util.solve_iteratively(science, reference, use_pixels=use_pixels, show=show,
-                                                    percent=percent, use_mask=use_mask_for_gain, pixstack_limit)
+                                                    percent=percent, use_mask=use_mask_for_gain, pixstack_limit=pixstack_limit)
     else:
         science.zero_point = gain_ratio
 
@@ -424,7 +424,7 @@ def run_subtraction(science_image, reference_image, science_psf, reference_psf, 
 
     science = ImageClass(science_image, science_psf, science_mask, n_stamps, science_saturation, science_variance)
     reference = ImageClass(reference_image, reference_psf, reference_mask, n_stamps, reference_saturation, reference_variance)
-    difference = calculate_difference_image(science, reference, gain_ratio, gain_mask, use_pixels, show, percent, use_mask_for_gain, pixstack_limit)
+    difference = calculate_difference_image(science, reference, gain_ratio, gain_mask, use_pixels, show, percent, use_mask_for_gain, pixstack_limit=pixstack_limit)
     difference_zero_point = calculate_difference_image_zero_point(science, reference)
     difference_psf = calculate_difference_psf(science, reference, difference_zero_point)
     normalized_difference = normalize_difference_image(difference, difference_zero_point, science, reference, normalization)

--- a/PyZOGY/subtract.py
+++ b/PyZOGY/subtract.py
@@ -12,7 +12,7 @@ else:
     overwrite = {'overwrite': True}
 
 
-def calculate_difference_image(science, reference, gain_ratio=np.inf, gain_mask=None, use_pixels=False, show=False, percent=99, use_mask_for_gain=True):
+def calculate_difference_image(science, reference, gain_ratio=np.inf, gain_mask=None, use_pixels=False, show=False, percent=99, use_mask_for_gain=True, pixstack_limit=None):
     """
     Calculate the difference image using the Zackay algorithm.
 
@@ -38,6 +38,8 @@ def calculate_difference_image(science, reference, gain_ratio=np.inf, gain_mask=
         Display debuggin plots during fitting.
     percent : float, optional
         Percentile cutoff to use for fitting the gain ratio.
+    pixstack_limit : int, optional
+        Number of active object pixels in Sep, set with sep.set_extract_pixstack
 
     Returns
     -------
@@ -55,7 +57,7 @@ def calculate_difference_image(science, reference, gain_ratio=np.inf, gain_mask=
             science.mask[gain_mask_data == 1] = 1
             reference.mask[gain_mask_data == 1] = 1
         science.zero_point = util.solve_iteratively(science, reference, use_pixels=use_pixels, show=show,
-                                                    percent=percent, use_mask=use_mask_for_gain)
+                                                    percent=percent, use_mask=use_mask_for_gain, pixstack_limit)
     else:
         science.zero_point = gain_ratio
 
@@ -364,7 +366,7 @@ def run_subtraction(science_image, reference_image, science_psf, reference_psf, 
                     science_saturation=False, reference_saturation=False, science_variance=None,
                     reference_variance=None, matched_filter=False, photometry=False,
                     gain_ratio=np.inf, gain_mask=None, use_pixels=False, show=False, percent=99,
-                    corrected=False, use_mask_for_gain=True):
+                    corrected=False, use_mask_for_gain=True, pixstack_limit=None):
     """
     Run full subtraction given filenames and parameters
     
@@ -416,11 +418,13 @@ def run_subtraction(science_image, reference_image, science_psf, reference_psf, 
         Percentile cutoff for gain matching.
     corrected : bool, optional
         Noise correct matched filter image.
+    pixstack_limit : int
+        Number of active object pixels in Sep, set with sep.set_extract_pixstack
     """
 
     science = ImageClass(science_image, science_psf, science_mask, n_stamps, science_saturation, science_variance)
     reference = ImageClass(reference_image, reference_psf, reference_mask, n_stamps, reference_saturation, reference_variance)
-    difference = calculate_difference_image(science, reference, gain_ratio, gain_mask, use_pixels, show, percent, use_mask_for_gain)
+    difference = calculate_difference_image(science, reference, gain_ratio, gain_mask, use_pixels, show, percent, use_mask_for_gain, pixstack_limit)
     difference_zero_point = calculate_difference_image_zero_point(science, reference)
     difference_psf = calculate_difference_psf(science, reference, difference_zero_point)
     normalized_difference = normalize_difference_image(difference, difference_zero_point, science, reference, normalization)

--- a/PyZOGY/util.py
+++ b/PyZOGY/util.py
@@ -246,7 +246,7 @@ def solve_iteratively(science, reference, mask_tolerance=10e-5, gain_tolerance=1
 
         # do a linear robust regression between convolved image
         x, y = join_images(science_convolved_image, science_mask_convolved, reference_convolved_image, 
-                           reference_mask_convolved, sigma_cut, use_pixels, show, percent, pixstack_limit)
+                           reference_mask_convolved, sigma_cut, use_pixels, show, percent, pixstack_limit=pixstack_limit)
         robust_fit = stats.RLM(y, stats.add_constant(x), stats.robust.norms.TukeyBiweight()).fit()
         parameters = robust_fit.params
         gain0 = gain

--- a/PyZOGY/util.py
+++ b/PyZOGY/util.py
@@ -78,7 +78,7 @@ def interpolate_bad_pixels(image, median_size=6, fname=''):
     return interpolated_image
 
 
-def join_images(science_raw, science_mask, reference_raw, reference_mask, sigma_cut, use_pixels=False, show=False, percent=99):
+def join_images(science_raw, science_mask, reference_raw, reference_mask, sigma_cut, use_pixels=False, show=False, percent=99, pixstack_limit=None):
     """Join two images to fittable vectors"""
 
     science = np.ma.array(science_raw, mask=science_mask, copy=True)
@@ -99,7 +99,8 @@ def join_images(science_raw, science_mask, reference_raw, reference_mask, sigma_
         if science_flatten.size == 0:
             logging.error('No pixels in common at this percentile ({0}); lower and try again'.format(percent))
     else:
-        pixstack_limit = science.size // 20
+        if pixstack_limit is None:
+            pixstack_limit = science.size // 20
         if pixstack_limit > 300000:
             sep.set_extract_pixstack(pixstack_limit)
         science_sources = sep.extract(np.ascontiguousarray(science.data), thresh=sigma_cut, err=science_std, mask=np.ascontiguousarray(science.mask))
@@ -176,7 +177,7 @@ def pad_to_power2(data, value='median'):
 
 
 def solve_iteratively(science, reference, mask_tolerance=10e-5, gain_tolerance=10e-6,
-                      max_iterations=5, sigma_cut=5, use_pixels=False, show=False, percent=99, use_mask=True):
+                      max_iterations=5, sigma_cut=5, use_pixels=False, show=False, percent=99, use_mask=True, pixstack_limit=None):
     """Solve for linear fit iteratively"""
 
     gain = 1.
@@ -245,7 +246,7 @@ def solve_iteratively(science, reference, mask_tolerance=10e-5, gain_tolerance=1
 
         # do a linear robust regression between convolved image
         x, y = join_images(science_convolved_image, science_mask_convolved, reference_convolved_image, 
-                           reference_mask_convolved, sigma_cut, use_pixels, show, percent)
+                           reference_mask_convolved, sigma_cut, use_pixels, show, percent, pixstack_limit)
         robust_fit = stats.RLM(y, stats.add_constant(x), stats.robust.norms.TukeyBiweight()).fit()
         parameters = robust_fit.params
         gain0 = gain


### PR DESCRIPTION
Some images with a lot of sources exceed the default number of active pixel sources (science.size//20) allowed by sep with the error:

> Exception: internal pixel buffer full: The limit of 838860 active object pixels over the detection threshold was reached. Check that the image is background subtracted and the detection threshold is not too low. If you need to increase the limit, use set_extract_pixstack.

This PR adds the flag --pixstack-limit so that the user can manually push this limit higher

This was tested on the LCO image `cpt1m010-fl16-20180812-0165-e91.fits` and the template image `cpt1m013-fa14-20200720-0165-e91.temp.fits` with the command (all files referenced here are the output from lcogtsnpipe):

```pyzogy --science-image _targ.fits --reference-image _temp.fits --science-psf _targpsf.fits --output test.fits --science-mask _targmask.fits --reference-psf _temppsf.fits --reference-mask _tempmask.fits --science-saturation 141692 --reference-saturation 143497 --science-variance targnoise.fits --reference-variance tempnoise.fits --n-stamps 1 --normalization t```

which produced the above error as expected then with

```pyzogy --science-image _targ.fits --reference-image _temp.fits --science-psf _targpsf.fits --output test.fits --science-mask _targmask.fits --reference-psf _temppsf.fits --reference-mask _tempmask.fits --science-saturation 141692 --reference-saturation 143497 --science-variance targnoise.fits --reference-variance tempnoise.fits --n-stamps 1 --normalization t --pixstack-limit 16000000```

which successfully finished running and produced a good difference image. 
